### PR TITLE
bug/MOD-CRASH-1

### DIFF
--- a/Source/Private/GameFeatureAction_AddAbilities.cpp
+++ b/Source/Private/GameFeatureAction_AddAbilities.cpp
@@ -42,7 +42,7 @@ void UGameFeatureAction_AddAbilities::ResetExtension()
 void UGameFeatureAction_AddAbilities::AddToWorld(const FWorldContext& WorldContext)
 {
 	if (UGameFrameworkComponentManager* ComponentManager = GetGameFrameworkComponentManager(WorldContext);
-		!TargetPawnClass.IsNull())
+		IsValid(ComponentManager) && !TargetPawnClass.IsNull())
 	{
 		const UGameFrameworkComponentManager::FExtensionHandlerDelegate& ExtensionHandlerDelegate =
 			UGameFrameworkComponentManager::FExtensionHandlerDelegate::CreateUObject(this,

--- a/Source/Private/GameFeatureAction_AddAttribute.cpp
+++ b/Source/Private/GameFeatureAction_AddAttribute.cpp
@@ -39,7 +39,7 @@ void UGameFeatureAction_AddAttribute::ResetExtension()
 void UGameFeatureAction_AddAttribute::AddToWorld(const FWorldContext& WorldContext)
 {
 	if (UGameFrameworkComponentManager* ComponentManager = GetGameFrameworkComponentManager(WorldContext);
-		!TargetPawnClass.IsNull())
+		IsValid(ComponentManager) && !TargetPawnClass.IsNull())
 	{
 		const UGameFrameworkComponentManager::FExtensionHandlerDelegate& ExtensionHandlerDelegate =
 			UGameFrameworkComponentManager::FExtensionHandlerDelegate::CreateUObject(this,

--- a/Source/Private/GameFeatureAction_AddEffects.cpp
+++ b/Source/Private/GameFeatureAction_AddEffects.cpp
@@ -39,7 +39,7 @@ void UGameFeatureAction_AddEffects::ResetExtension()
 void UGameFeatureAction_AddEffects::AddToWorld(const FWorldContext& WorldContext)
 {
 	if (UGameFrameworkComponentManager* ComponentManager = GetGameFrameworkComponentManager(WorldContext);
-		!TargetPawnClass.IsNull())
+		IsValid(ComponentManager) && !TargetPawnClass.IsNull())
 	{
 		const UGameFrameworkComponentManager::FExtensionHandlerDelegate& ExtensionHandlerDelegate =
 			UGameFrameworkComponentManager::FExtensionHandlerDelegate::CreateUObject(this,

--- a/Source/Private/GameFeatureAction_AddInputs.cpp
+++ b/Source/Private/GameFeatureAction_AddInputs.cpp
@@ -43,7 +43,7 @@ void UGameFeatureAction_AddInputs::ResetExtension()
 void UGameFeatureAction_AddInputs::AddToWorld(const FWorldContext& WorldContext)
 {
 	if (UGameFrameworkComponentManager* ComponentManager = GetGameFrameworkComponentManager(WorldContext);
-		!TargetPawnClass.IsNull())
+		IsValid(ComponentManager) && !TargetPawnClass.IsNull())
 	{
 		const UGameFrameworkComponentManager::FExtensionHandlerDelegate& ExtensionHandlerDelegate =
 			UGameFrameworkComponentManager::FExtensionHandlerDelegate::CreateUObject(this,

--- a/Source/Private/GameFeatureAction_SpawnActors.cpp
+++ b/Source/Private/GameFeatureAction_SpawnActors.cpp
@@ -51,7 +51,7 @@ void UGameFeatureAction_SpawnActors::SpawnActors(UWorld* WorldReference)
 
 			UE_LOG(LogGameplayFeaturesExtraActions, Display,
 			       TEXT("%s: Spawning actor %s on world %s"), *FString(__func__),
-			       *ClassToSpawn->GetName(), *TargetLevel.GetAssetName());
+			       *ClassToSpawn->GetName(), *WorldReference->GetName());
 
 			AActor* SpawnedActor = WorldReference->SpawnActor<AActor>(ClassToSpawn, SpawnTransform);
 			SpawnedActors.Add(SpawnedActor);


### PR DESCRIPTION
Add a new verification to avoid null component managers and set ActorSpawn log to use the world reference name instead asset name.